### PR TITLE
default to `dpla` for streamlined use

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -22,7 +22,9 @@ func Commands(msg *disgord.Message, s disgord.Session, c *deepl.Client, config c
 	} else if prefix == "gtr" {
 		Gtr(msg, s)
 	} else if prefix == "info" {
-		msg.Reply(context.Background(), s, "Diru is a Discord bot that can translate text.\n\n**Technical information:**\n```" + "OS: " + runtime.GOOS + "\n" + "Arch: " + runtime.GOARCH + "\n" + "Go Version: " + runtime.Version()+"\n" + "Version: 1.1.0" + "\n" + "Source: https://github.com/Lucxjo/Diru/```")
+		msg.Reply(context.Background(), s, "Diru is a Discord bot that can translate text.\n\n**Technical information:**\n```" + 
+		"OS: " + runtime.GOOS + "\n" + "Arch: " + runtime.GOARCH + "\n" + "Go Version: " + runtime.Version()+"\n" + 
+		"Version: 1.1.0" + "\n" + "Source: https://github.com/Lucxjo/Diru/```")
 	} else if prefix == "issue" {
 		msg.Reply(context.Background(), s, "Please report any issues on the GitHub issue tracker: https://github.com/Lucxjo/Diru/issues")
 	} else if prefix == "vote" && config.Topgg.Token != "" && config.Topgg.Id != "" {
@@ -30,7 +32,13 @@ func Commands(msg *disgord.Message, s disgord.Session, c *deepl.Client, config c
 	} else if prefix == "help" {
 		bot, _ := s.Gateway().GetBot()
 		utils.SendTopggData(config.Topgg.Token, config.Topgg.Id, bot.Shards, config.DiscordToken)
-		msg.Reply(context.Background(), s, "**Commands**\nAll commands require the bot to be mentioned\n\n`@Diru dpl <lang> <phrase>`\nTranslates a phrase to a specified language with DeepL.\n\n`@Diru dpla <phrase>`\nTranslates a phrase to English (British) with DeepL.\n\n`@Diru gtr <lang> <phrase>`\nTranslates a phrase to a specified language with Google Translate\n\n`@Diru info`\nDisplays technical information about the bot.\n\n`@Diru issue`\nDisplays a link to the GitHub issue tracker.")
+		msg.Reply(context.Background(), s, "**Commands**\nAll commands require the bot to be mentioned\n\n" + 
+		"`@Diru dpl <lang> <phrase>`\nTranslates a phrase to a specified language with DeepL.\n\n" + 
+		"`@Diru dpla <phrase>`\nTranslates a phrase to English (British) with DeepL.\n\n" + 
+		"`@Diru <phrase>` \ndoes the same thing as `dpla`\n\n" + 
+		"`@Diru gtr <lang> <phrase>`\nTranslates a phrase to a specified language with Google Translate\n\n" + 
+		"`@Diru info`\nDisplays technical information about the bot.\n\n" + 
+		"`@Diru issue`\nDisplays a link to the GitHub issue tracker.")
 	} else {
 		// Default to DPLA if none of the above prefixes
 		Dpla(msg, s, c)

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -32,8 +32,7 @@ func Commands(msg *disgord.Message, s disgord.Session, c *deepl.Client, config c
 		utils.SendTopggData(config.Topgg.Token, config.Topgg.Id, bot.Shards, config.DiscordToken)
 		msg.Reply(context.Background(), s, "**Commands**\nAll commands require the bot to be mentioned\n\n`@Diru dpl <lang> <phrase>`\nTranslates a phrase to a specified language with DeepL.\n\n`@Diru dpla <phrase>`\nTranslates a phrase to English (British) with DeepL.\n\n`@Diru gtr <lang> <phrase>`\nTranslates a phrase to a specified language with Google Translate\n\n`@Diru info`\nDisplays technical information about the bot.\n\n`@Diru issue`\nDisplays a link to the GitHub issue tracker.")
 	} else {
-		bot, _ := s.Gateway().GetBot()
-		utils.SendTopggData(config.Topgg.Token, config.Topgg.Id, bot.Shards, config.DiscordToken)
-		msg.Reply(context.Background(), s, "Command not found.\nPlease use `@Diru help` to see a list of available commands.")
+		// Default to DPLA if none of the above prefixes
+		Dpla(msg, s, c)
 	}
 }

--- a/cmd/dpla.go
+++ b/cmd/dpla.go
@@ -15,8 +15,13 @@ func Dpla(msg *disgord.Message, s disgord.Session, c *deeplgo.Client) {
 		text := msg.ReferencedMessage.Content
 
 		msg.Reply(context.Background(), s, deepl.AutoTranslate(text, c))
-	} else {
+	} else if strings.Contains(msg.Content, "dpl") {
 		text := strings.Split(msg.Content, " ")[2:]
+		tx := strings.Join(text, " ")
+		msg.Reply(context.Background(), s, deepl.AutoTranslate(tx, c))
+	} else {
+		// Because this is the option if no prefix is chosen, we need to start from index 1
+		text := strings.Split(msg.Content, " ")[1:]
 		tx := strings.Join(text, " ")
 		msg.Reply(context.Background(), s, deepl.AutoTranslate(tx, c))
 	}

--- a/diru.go
+++ b/diru.go
@@ -49,7 +49,9 @@ func main() {
 		}
 	})
 
-	client.Gateway().WithMiddleware(cont.HasBotMentionPrefix).MessageCreate(func(s disgord.Session, h *disgord.MessageCreate) {
+	cont.SetPrefix("?diru")
+
+	client.Gateway().WithMiddleware(cont.HasPrefix).MessageCreate(func(s disgord.Session, h *disgord.MessageCreate) {
 		if !h.Message.Author.Bot {
 			cmd.Commands(h.Message, s, dClient, config)
 		}

--- a/diru.go
+++ b/diru.go
@@ -49,9 +49,7 @@ func main() {
 		}
 	})
 
-	cont.SetPrefix("?diru")
-
-	client.Gateway().WithMiddleware(cont.HasPrefix).MessageCreate(func(s disgord.Session, h *disgord.MessageCreate) {
+	client.Gateway().WithMiddleware(cont.HasBotMentionPrefix).MessageCreate(func(s disgord.Session, h *disgord.MessageCreate) {
 		if !h.Message.Author.Bot {
 			cmd.Commands(h.Message, s, dClient, config)
 		}


### PR DESCRIPTION
### Reasoning

At the moment, from what I can see, Diru can be used in two ways in the case of using `dpla`:

1. Copying the text you want to translate, typing `@Diru`, then typing `dpla`, then pasting your copied text
2. Replying to a message containing the text you want translated, typing `@Diru`, then typing `dpla`.

In either case I was wondering if invoking the bot could be made more streamlined, for example:

- Hit reply to comment with text needing translation, type `?diru`. This would default to using `dpla` and would not require ensuring you have to `@` the bot correctly. 

### Other Notes

I am not at all experienced in Go and nor does my country (Australia) have access to the DeepL API which would be my preference to work on. This PR is just a rough draft to accompany my suggestion. Please let me know what you think.

@Lucxjo thank you for your hard work so far.

## Update 04/06/22

- Keeping mentions is better than having the bot have to listen and read every single message, particularly in terms of server load and efficiency
- Perhaps we can still look at using `dpla` by default
